### PR TITLE
fix: set metadataBase for correct og:image URL

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,7 +9,10 @@ const font = Poor_Story({
   subsets: ['latin']
 })
 
+const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://boardgame.joostory.net'
+
 export const metadata: Metadata = {
+  metadataBase: new URL(baseUrl),
   title: '보드게임 도우미',
   description: '보드게임을 위한 도구들입니다.',
   openGraph: {


### PR DESCRIPTION
정적 빌드 시 og:image 절대 경로가 올바르게 설정되도록 metadataBase에 실제 배포 도메인(https://boardgame.joostory.net)을 지정했습니다.